### PR TITLE
feat(jira): add comment, transition, and watcher tools

### DIFF
--- a/src/jira/api.ts
+++ b/src/jira/api.ts
@@ -1,5 +1,11 @@
 import fetch from "node-fetch";
-import { JiraCreateResponse, JiraSearchResponse } from "./types.js";
+import {
+  JiraCreateResponse,
+  JiraSearchResponse,
+  JiraCommentResponse,
+  JiraCommentsListResponse,
+  JiraTransitionsResponse,
+} from "./types.js";
 
 // Helper function to update a JIRA ticket
 export async function updateJiraTicket(
@@ -231,6 +237,371 @@ export async function searchJiraTickets(
     return {
       success: false,
       data: {},
+      errorMessage: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+// Helper function to add a comment to a JIRA ticket
+export async function addJiraComment(
+  ticketKey: string,
+  body: any,
+  auth: string
+): Promise<{
+  success: boolean;
+  data?: JiraCommentResponse;
+  errorMessage?: string;
+}> {
+  const jiraUrl = `https://${process.env.JIRA_HOST}/rest/api/3/issue/${ticketKey}/comment`;
+
+  console.error("JIRA Add Comment URL:", jiraUrl);
+
+  try {
+    const response = await fetch(jiraUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Basic ${auth}`,
+      },
+      body: JSON.stringify({ body }),
+    });
+
+    if (response.status === 201) {
+      const responseData = (await response.json()) as JiraCommentResponse;
+      return { success: true, data: responseData };
+    }
+
+    let errorMessage = `Status: ${response.status} ${response.statusText}`;
+    try {
+      const responseData = (await response.json()) as JiraCommentResponse;
+      console.error("Error adding comment:", responseData);
+      if (responseData.errorMessages && responseData.errorMessages.length > 0) {
+        errorMessage = responseData.errorMessages.join(", ");
+      } else if (responseData.errors) {
+        errorMessage = JSON.stringify(responseData.errors);
+      }
+    } catch (parseError) {
+      console.error("Error parsing error response:", parseError);
+    }
+
+    return { success: false, errorMessage };
+  } catch (error) {
+    console.error("Exception adding comment:", error);
+    return {
+      success: false,
+      errorMessage: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+// Helper function to get comments from a JIRA ticket
+export async function getJiraComments(
+  ticketKey: string,
+  maxResults: number,
+  auth: string
+): Promise<{
+  success: boolean;
+  data?: JiraCommentsListResponse;
+  errorMessage?: string;
+}> {
+  const jiraUrl = `https://${process.env.JIRA_HOST}/rest/api/3/issue/${ticketKey}/comment?maxResults=${maxResults}`;
+
+  console.error("JIRA Get Comments URL:", jiraUrl);
+
+  try {
+    const response = await fetch(jiraUrl, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Basic ${auth}`,
+      },
+    });
+
+    const responseData = (await response.json()) as JiraCommentsListResponse;
+
+    if (!response.ok) {
+      console.error("Error getting comments:", responseData);
+      let errorMessage = `Status: ${response.status} ${response.statusText}`;
+      if (responseData.errorMessages && responseData.errorMessages.length > 0) {
+        errorMessage = responseData.errorMessages.join(", ");
+      }
+      return { success: false, data: responseData, errorMessage };
+    }
+
+    return { success: true, data: responseData };
+  } catch (error) {
+    console.error("Exception getting comments:", error);
+    return {
+      success: false,
+      errorMessage: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+// Helper function to get available transitions for a JIRA ticket
+export async function getJiraTransitions(
+  ticketKey: string,
+  auth: string
+): Promise<{
+  success: boolean;
+  data?: JiraTransitionsResponse;
+  errorMessage?: string;
+}> {
+  const jiraUrl = `https://${process.env.JIRA_HOST}/rest/api/3/issue/${ticketKey}/transitions`;
+
+  console.error("JIRA Get Transitions URL:", jiraUrl);
+
+  try {
+    const response = await fetch(jiraUrl, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Basic ${auth}`,
+      },
+    });
+
+    const responseData = (await response.json()) as JiraTransitionsResponse;
+
+    if (!response.ok) {
+      console.error("Error getting transitions:", responseData);
+      let errorMessage = `Status: ${response.status} ${response.statusText}`;
+      if (responseData.errorMessages && responseData.errorMessages.length > 0) {
+        errorMessage = responseData.errorMessages.join(", ");
+      }
+      return { success: false, data: responseData, errorMessage };
+    }
+
+    return { success: true, data: responseData };
+  } catch (error) {
+    console.error("Exception getting transitions:", error);
+    return {
+      success: false,
+      errorMessage: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+// Helper function to transition a JIRA ticket
+export async function transitionJiraTicket(
+  ticketKey: string,
+  transitionId: string,
+  comment: any | undefined,
+  auth: string
+): Promise<{
+  success: boolean;
+  errorMessage?: string;
+}> {
+  const jiraUrl = `https://${process.env.JIRA_HOST}/rest/api/3/issue/${ticketKey}/transitions`;
+
+  const payload: any = {
+    transition: { id: transitionId },
+  };
+
+  if (comment) {
+    payload.update = {
+      comment: [{ add: { body: comment } }],
+    };
+  }
+
+  console.error("JIRA Transition URL:", jiraUrl);
+  console.error("JIRA Transition Payload:", JSON.stringify(payload, null, 2));
+
+  try {
+    const response = await fetch(jiraUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Basic ${auth}`,
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (response.status === 204) {
+      return { success: true };
+    }
+
+    let errorMessage = `Status: ${response.status} ${response.statusText}`;
+    try {
+      const responseData = (await response.json()) as {
+        errorMessages?: string[];
+        errors?: Record<string, string>;
+      };
+      console.error("Error transitioning ticket:", responseData);
+      if (responseData.errorMessages && responseData.errorMessages.length > 0) {
+        errorMessage = responseData.errorMessages.join(", ");
+      } else if (responseData.errors) {
+        errorMessage = JSON.stringify(responseData.errors);
+      }
+    } catch (parseError) {
+      console.error("Error parsing error response:", parseError);
+    }
+
+    return { success: false, errorMessage };
+  } catch (error) {
+    console.error("Exception transitioning ticket:", error);
+    return {
+      success: false,
+      errorMessage: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+// Helper function to assign a JIRA ticket
+export async function assignJiraTicket(
+  ticketKey: string,
+  accountId: string | null,
+  auth: string
+): Promise<{
+  success: boolean;
+  errorMessage?: string;
+}> {
+  const jiraUrl = `https://${process.env.JIRA_HOST}/rest/api/3/issue/${ticketKey}/assignee`;
+
+  const payload = { accountId };
+
+  console.error("JIRA Assign URL:", jiraUrl);
+  console.error("JIRA Assign Payload:", JSON.stringify(payload, null, 2));
+
+  try {
+    const response = await fetch(jiraUrl, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Basic ${auth}`,
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (response.status === 204) {
+      return { success: true };
+    }
+
+    let errorMessage = `Status: ${response.status} ${response.statusText}`;
+    try {
+      const responseData = (await response.json()) as {
+        errorMessages?: string[];
+        errors?: Record<string, string>;
+      };
+      console.error("Error assigning ticket:", responseData);
+      if (responseData.errorMessages && responseData.errorMessages.length > 0) {
+        errorMessage = responseData.errorMessages.join(", ");
+      } else if (responseData.errors) {
+        errorMessage = JSON.stringify(responseData.errors);
+      }
+    } catch (parseError) {
+      console.error("Error parsing error response:", parseError);
+    }
+
+    return { success: false, errorMessage };
+  } catch (error) {
+    console.error("Exception assigning ticket:", error);
+    return {
+      success: false,
+      errorMessage: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+// Helper function to add a watcher to a JIRA ticket
+export async function addJiraWatcher(
+  ticketKey: string,
+  accountId: string,
+  auth: string
+): Promise<{
+  success: boolean;
+  errorMessage?: string;
+}> {
+  const jiraUrl = `https://${process.env.JIRA_HOST}/rest/api/3/issue/${ticketKey}/watchers`;
+
+  console.error("JIRA Add Watcher URL:", jiraUrl);
+
+  try {
+    const response = await fetch(jiraUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Basic ${auth}`,
+      },
+      body: JSON.stringify(accountId),
+    });
+
+    if (response.status === 204) {
+      return { success: true };
+    }
+
+    let errorMessage = `Status: ${response.status} ${response.statusText}`;
+    try {
+      const responseData = (await response.json()) as {
+        errorMessages?: string[];
+        errors?: Record<string, string>;
+      };
+      console.error("Error adding watcher:", responseData);
+      if (responseData.errorMessages && responseData.errorMessages.length > 0) {
+        errorMessage = responseData.errorMessages.join(", ");
+      } else if (responseData.errors) {
+        errorMessage = JSON.stringify(responseData.errors);
+      }
+    } catch (parseError) {
+      console.error("Error parsing error response:", parseError);
+    }
+
+    return { success: false, errorMessage };
+  } catch (error) {
+    console.error("Exception adding watcher:", error);
+    return {
+      success: false,
+      errorMessage: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+// Helper function to remove a watcher from a JIRA ticket
+export async function removeJiraWatcher(
+  ticketKey: string,
+  accountId: string,
+  auth: string
+): Promise<{
+  success: boolean;
+  errorMessage?: string;
+}> {
+  const jiraUrl = `https://${process.env.JIRA_HOST}/rest/api/3/issue/${ticketKey}/watchers?accountId=${encodeURIComponent(accountId)}`;
+
+  console.error("JIRA Remove Watcher URL:", jiraUrl);
+
+  try {
+    const response = await fetch(jiraUrl, {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Basic ${auth}`,
+      },
+    });
+
+    if (response.status === 204) {
+      return { success: true };
+    }
+
+    let errorMessage = `Status: ${response.status} ${response.statusText}`;
+    try {
+      const responseData = (await response.json()) as {
+        errorMessages?: string[];
+        errors?: Record<string, string>;
+      };
+      console.error("Error removing watcher:", responseData);
+      if (responseData.errorMessages && responseData.errorMessages.length > 0) {
+        errorMessage = responseData.errorMessages.join(", ");
+      } else if (responseData.errors) {
+        errorMessage = JSON.stringify(responseData.errors);
+      }
+    } catch (parseError) {
+      console.error("Error parsing error response:", parseError);
+    }
+
+    return { success: false, errorMessage };
+  } catch (error) {
+    console.error("Exception removing watcher:", error);
+    return {
+      success: false,
       errorMessage: error instanceof Error ? error.message : String(error),
     };
   }

--- a/src/jira/formatting.ts
+++ b/src/jira/formatting.ts
@@ -115,3 +115,59 @@ export function formatAcceptanceCriteria(criteria: string | undefined) {
     content: content,
   };
 }
+
+/**
+ * Extracts plain text from Atlassian Document Format (ADF).
+ * Recursively traverses the ADF structure to extract all text content.
+ *
+ * @param adf - The ADF document or node to extract text from
+ * @returns Plain text representation of the ADF content
+ */
+export function extractTextFromAdf(adf: any): string {
+  if (!adf) {
+    return "";
+  }
+
+  // If it's a string, return it directly
+  if (typeof adf === "string") {
+    return adf;
+  }
+
+  // If it's a text node, return the text
+  if (adf.type === "text" && adf.text) {
+    return adf.text;
+  }
+
+  // If it has content array, recursively extract text from each node
+  if (Array.isArray(adf.content)) {
+    const parts: string[] = [];
+
+    for (const node of adf.content) {
+      const text = extractTextFromAdf(node);
+      if (text) {
+        parts.push(text);
+      }
+    }
+
+    // Add appropriate separators based on node types
+    if (adf.type === "paragraph" || adf.type === "heading") {
+      return parts.join("") + "\n";
+    }
+
+    if (adf.type === "bulletList" || adf.type === "orderedList") {
+      return parts.join("");
+    }
+
+    if (adf.type === "listItem") {
+      return "• " + parts.join("") + "\n";
+    }
+
+    if (adf.type === "codeBlock") {
+      return "```\n" + parts.join("") + "\n```\n";
+    }
+
+    return parts.join("");
+  }
+
+  return "";
+}

--- a/src/jira/types.ts
+++ b/src/jira/types.ts
@@ -50,3 +50,39 @@ export type JiraSearchResponse = {
   maxResults?: number;
   startAt?: number;
 };
+
+// Comment types
+export type JiraCommentResponse = {
+  errorMessages?: string[];
+  errors?: Record<string, string>;
+  id?: string;
+  body?: any;
+  author?: { accountId: string; displayName: string };
+  created?: string;
+};
+
+export type JiraComment = {
+  id: string;
+  body: any;
+  author: { accountId: string; displayName: string };
+  created: string;
+  updated: string;
+};
+
+export type JiraCommentsListResponse = {
+  errorMessages?: string[];
+  comments?: JiraComment[];
+  total?: number;
+};
+
+// Transition types
+export type JiraTransition = {
+  id: string;
+  name: string;
+  to: { id: string; name: string };
+};
+
+export type JiraTransitionsResponse = {
+  errorMessages?: string[];
+  transitions?: JiraTransition[];
+};


### PR DESCRIPTION
Add new MCP tools for JIRA ticket management:
- add-comment: Add comments to tickets
- list-comments: Retrieve ticket comments with ADF-to-text conversion
- transition-ticket: Change ticket status with optional comment
- assign-ticket: Assign or unassign tickets
- add-watcher / remove-watcher: Manage ticket watchers

Enhance update-ticket with additional fields:
- summary, priority, labels, components, fix_versions, due_date